### PR TITLE
Return the created_at value from the graphql response

### DIFF
--- a/src/ghastoolkit/octokit/dependabot.py
+++ b/src/ghastoolkit/octokit/dependabot.py
@@ -42,10 +42,10 @@ class Dependabot:
                     # TODO: CWE info
                 )
                 dep_alert = DependencyAlert(
-                    severity=advisory.severity, 
-                    purl=purl, 
-                    advisory=advisory, 
-                    created_at=created_at
+                    severity=advisory.severity,
+                    purl=purl,
+                    advisory=advisory,
+                    created_at=created_at,
                 )
                 dep_alert.__data__ = data
                 results.append(dep_alert)

--- a/src/ghastoolkit/octokit/dependabot.py
+++ b/src/ghastoolkit/octokit/dependabot.py
@@ -34,6 +34,7 @@ class Dependabot:
                 data = alert.get("node", {})
                 package = data.get("securityVulnerability", {}).get("package", {})
                 purl = f"pkg:{package.get('ecosystem')}/{package.get('name')}".lower()
+                created_at = data.get("createdAt")
 
                 advisory = Advisory(
                     ghsa_id=data.get("securityAdvisory", {}).get("ghsaId"),
@@ -41,7 +42,10 @@ class Dependabot:
                     # TODO: CWE info
                 )
                 dep_alert = DependencyAlert(
-                    severity=advisory.severity, purl=purl, advisory=advisory
+                    severity=advisory.severity, 
+                    purl=purl, 
+                    advisory=advisory, 
+                    created_at=created_at
                 )
                 dep_alert.__data__ = data
                 results.append(dep_alert)


### PR DESCRIPTION
I'm hoping this change works the way you expect, it returns the `created_at` parameter that's expected as per the issue I raised: https://github.com/GeekMasher/ghastoolkit/issues/36

I've tested the response with the script mentioned in the issue, and I'm now getting the correct response:

```
> python.exe .\test_changes.py
2023-01-17 15:03:37
2023-01-17 15:03:37
2023-01-17 15:03:37
2023-01-17 15:03:37
2023-01-17 15:03:37
2023-01-19 16:19:52
2023-01-19 16:19:52
2023-01-19 16:19:52
2023-01-19 16:55:55
2023-01-19 16:55:55
2023-01-19 16:55:55
2023-01-20 11:55:37
2023-01-20 11:55:37
2023-01-20 11:55:38
2023-02-01 16:38:19
2023-06-24 23:15:29
[DependencyAlert(severity='LOW', advisory=Advisory(ghsa_id='GHSA-gxpj-cx7g-858c', severity='LOW', summary=None, url=None, cwes=[]), purl='pkg:npm/debug', created_at='2023-01-17T15:03:37Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-gwg9-rgvj-4h5j', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:npm/morgan', created_at='2023-01-17T15:03:37Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-82v2-mx6x-wq7q', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:npm/log4js', created_at='2023-01-17T15:03:37Z'), DependencyAlert(severity='CRITICAL', advisory=Advisory(ghsa_id='GHSA-phwq-j96m-2c2q', severity='CRITICAL', summary=None, url=None, cwes=[]), purl='pkg:npm/ejs', created_at='2023-01-17T15:03:37Z'), DependencyAlert(severity='HIGH', advisory=Advisory(ghsa_id='GHSA-9vvw-cc9w-f27h', severity='HIGH', summary=None, url=None, cwes=[]), purl='pkg:npm/debug', created_at='2023-01-17T15:03:37Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-3m2r-q8x3-xmf7', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:nuget/microsoft.aspnetcore.all', created_at='2023-01-19T16:19:52Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-cgpw-2gph-2r9g', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:nuget/microsoft.aspnetcore.all', created_at='2023-01-19T16:19:52Z'), DependencyAlert(severity='HIGH', advisory=Advisory(ghsa_id='GHSA-3wcj-rg8q-9cqv', severity='HIGH', summary=None, url=None, cwes=[]), purl='pkg:nuget/microsoft.aspnetcore.all', created_at='2023-01-19T16:19:52Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-3m2r-q8x3-xmf7', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:nuget/microsoft.aspnetcore.all', created_at='2023-01-19T16:55:55Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-cgpw-2gph-2r9g', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:nuget/microsoft.aspnetcore.all', created_at='2023-01-19T16:55:55Z'), DependencyAlert(severity='HIGH', advisory=Advisory(ghsa_id='GHSA-5crp-9r3c-p9vr', severity='HIGH', summary=None, url=None, cwes=[]), purl='pkg:nuget/newtonsoft.json', created_at='2023-01-19T16:55:55Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-45q2-34rf-mr94', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:npm/mquery', created_at='2023-01-20T11:55:37Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-p92x-r36w-9395', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:npm/mpath', created_at='2023-01-20T11:55:37Z'), DependencyAlert(severity='HIGH', advisory=Advisory(ghsa_id='GHSA-hrpp-h998-j3pp', severity='HIGH', summary=None, url=None, cwes=[]), purl='pkg:npm/qs', created_at='2023-01-20T11:55:38Z'), DependencyAlert(severity='HIGH', advisory=Advisory(ghsa_id='GHSA-f825-f98c-gj3g', severity='HIGH', summary=None, url=None, cwes=[]), purl='pkg:npm/mongoose', created_at='2023-02-01T16:38:19Z'), DependencyAlert(severity='MODERATE', advisory=Advisory(ghsa_id='GHSA-c2qf-rxjj-qqgw', severity='MODERATE', summary=None, url=None, cwes=[]), purl='pkg:npm/semver', created_at='2023-06-24T23:15:29Z')]
```

Thanks