### PR TITLE
Add support for PR comments

### DIFF
--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -99,6 +99,53 @@ class Repository:
                 result.append(commit.get("sha"))
         return result
 
+    def getPullRequestComments(self) -> list[dict[str, int | str]]:
+        """Get list of Pull Request comments."""
+        result = []
+        if self.isInPullRequest():
+            from ghastoolkit.octokit.octokit import RestRequest
+
+            issue_number = self.getPullRequestNumber()
+            response = RestRequest().get(
+                "/repos/{owner}/{repo}/issues/{issue_number}/comments",
+                {"issue_number": issue_number},
+            )
+            for comment in response:
+                result.append(
+                    {
+                        "id": comment.get("id"),
+                        "body": comment.get("body", ""),
+                    }
+                )
+        return result
+
+    def createPullRequestComment(self, comment_body: str) -> None:
+        """Create a new Pull Request comment."""
+        if self.isInPullRequest():
+            from ghastoolkit.octokit.octokit import RestRequest
+
+            issue_number = self.getPullRequestNumber()
+            RestRequest().postJson(
+                "/repos/{owner}/{repo}/issues/{issue_number}/comments",
+                {"body": comment_body},
+                expected=201,
+                parameters={"issue_number": issue_number},
+            )
+        return
+
+    def updatePullRequestComment(self, comment_id: int, comment_body: str) -> None:
+        """Update an existing Pull Request comment."""
+        if self.isInPullRequest():
+            from ghastoolkit.octokit.octokit import RestRequest
+
+            RestRequest().patchJson(
+                "/repos/{owner}/{repo}/issues/comments{comment_id}",
+                {"body": comment_body},
+                expected=200,
+                parameters={"comment_id": comment_id},
+            )
+        return
+
     @property
     def clone_url(self) -> str:
         """Repository clone URL."""

--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import subprocess
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 from urllib.parse import urlparse
 
 

--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -99,7 +99,7 @@ class Repository:
                 result.append(commit.get("sha"))
         return result
 
-    def getPullRequestComments(self) -> list[dict[str, int | str]]:
+    def getPullRequestComments(self) -> list[dict[str, Union[int, str]]]:
         """Get list of Pull Request comments."""
         result = []
         if self.isInPullRequest():

--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -139,7 +139,7 @@ class Repository:
             from ghastoolkit.octokit.octokit import RestRequest
 
             RestRequest().patchJson(
-                "/repos/{owner}/{repo}/issues/comments{comment_id}",
+                "/repos/{owner}/{repo}/issues/comments/{comment_id}",
                 {"body": comment_body},
                 expected=200,
                 parameters={"comment_id": comment_id},

--- a/src/ghastoolkit/octokit/octokit.py
+++ b/src/ghastoolkit/octokit/octokit.py
@@ -250,7 +250,7 @@ class RestRequest:
             raise Exception(f"Failed to post data")
 
         return response.json()
-    
+
     def patchJson(
         self, path: str, data: dict, expected: int = 200, parameters={}
     ) -> dict:

--- a/src/ghastoolkit/octokit/octokit.py
+++ b/src/ghastoolkit/octokit/octokit.py
@@ -229,12 +229,14 @@ class RestRequest:
 
         return result
 
-    def postJson(self, path: str, data: dict, expected: int = 200) -> dict:
+    def postJson(
+        self, path: str, data: dict, expected: int = 200, parameters={}
+    ) -> dict:
         repo = self.repository or GitHub.repository
         if not repo:
             raise Exception("Repository needs to be set")
 
-        url = Octokit.route(path, repo, rtype="rest")
+        url = Octokit.route(path, repo, rtype="rest", **parameters)
         logger.debug(f"Posting content from URL :: {url}")
 
         response = self.session.post(url, json=data)
@@ -246,6 +248,28 @@ class RestRequest:
             if known_error:
                 raise Exception(known_error)
             raise Exception(f"Failed to post data")
+
+        return response.json()
+    
+    def patchJson(
+        self, path: str, data: dict, expected: int = 200, parameters={}
+    ) -> dict:
+        repo = self.repository or GitHub.repository
+        if not repo:
+            raise Exception("Repository needs to be set")
+
+        url = Octokit.route(path, repo, rtype="rest", **parameters)
+        logger.debug(f"Patching content from URL :: {url}")
+
+        response = self.session.patch(url, json=data)
+
+        if response.status_code != expected:
+            logger.error(f"Error code from server :: {response.status_code}")
+            logger.error(f"{response.content}")
+            known_error = __OCTOKIT_ERRORS__.get(response.status_code)
+            if known_error:
+                raise Exception(known_error)
+            raise Exception("Failed to patch data")
 
         return response.json()
 


### PR DESCRIPTION
Adding support for working with PR comments.

The purpose of this feature is to lay some groundwork for allowing Policy as Code to create PR comment summaries of workflow runs (see [Issue 42 in PaC](https://github.com/advanced-security/policy-as-code/issues/42) for reference).

Open to suggestions for changes or different implementations!

### Get PR comments
- REST API - `/repos/{owner}/{repo}/issues/{issue_number}/comments`
- GET
- `issue_number` - the PR #

### Create new PR comment
- REST API - `/repos/{owner}/{repo}/issues/{issue_number}/comments`
- POST
- `issue_number` - the PR #
- body in request - string representing the comment to be created
- expected response code - 201

### Update existing PR comment
- REST API - `/repos/{owner}/{repo}/issues/comments/{comment_id}`
- PATCH
- `comment_id` - ID of the existing comment to update
- body in request - string representing the updated comment contents, this replaces the previous contents of the comment
- expected response code - 200