### PR TITLE
Allow `Repository` class to use its own token

### DIFF
--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -39,7 +39,7 @@ class Repository:
     repo_token: Optional[str] = None
     """Repository Access Token"""
 
-    github_app_token: bool = False
+    is_github_app_token: bool = False
     """Whether the token is a GitHub App Token"""
 
     def __post_init__(self) -> None:
@@ -162,7 +162,7 @@ class Repository:
         """Repository clone URL."""
         url = urlparse(GitHub.instance)
         if self.repo_token:
-            if self.github_app_token:
+            if self.is_github_app_token:
                 return f"{url.scheme}://x-access-token:{self.repo_token}@{url.netloc}/{self.owner}/{self.repo}"
             else:
                 return f"{url.scheme}://{self.repo_token}@{url.netloc}/{self.owner}/{self.repo}"

--- a/src/ghastoolkit/octokit/github.py
+++ b/src/ghastoolkit/octokit/github.py
@@ -36,6 +36,12 @@ class Repository:
     clone_path: Optional[str] = None
     """Clone Path"""
 
+    repo_token: Optional[str] = None
+    """Repository Access Token"""
+
+    github_app_token: bool = False
+    """Whether the token is a GitHub App Token"""
+
     def __post_init__(self) -> None:
         if self.reference and not self.branch:
             if not self.isInPullRequest():
@@ -154,11 +160,15 @@ class Repository:
     @property
     def clone_url(self) -> str:
         """Repository clone URL."""
-        if GitHub.github_app:
-            url = urlparse(GitHub.instance)
+        url = urlparse(GitHub.instance)
+        if self.repo_token:
+            if self.github_app_token:
+                return f"{url.scheme}://x-access-token:{self.repo_token}@{url.netloc}/{self.owner}/{self.repo}"
+            else:
+                return f"{url.scheme}://{self.repo_token}@{url.netloc}/{self.owner}/{self.repo}"
+        elif GitHub.github_app:
             return f"{url.scheme}://x-access-token:{GitHub.token}@{url.netloc}/{self.owner}/{self.repo}.git"
         elif GitHub.token:
-            url = urlparse(GitHub.instance)
             return f"{url.scheme}://{GitHub.token}@{url.netloc}/{self.owner}/{self.repo}.git"
         return f"{GitHub.instance}/{self.owner}/{self.repo}.git"
 


### PR DESCRIPTION
This change allows an instance of the `Repository` class to use its own token for cloning the repository instead of always using the static/singleton defined in the `GitHub` class. This supports situations where a user of ghastoolkit needs to work with repositories that are owned by different users/organizations and therefore require different tokens for access.

This change supports the feature requested for Policy as Code in [https://github.com/advanced-security/policy-as-code/issues/62](https://github.com/advanced-security/policy-as-code/issues/62), and the suggested implementation in [https://github.com/advanced-security/policy-as-code/pull/61](https://github.com/advanced-security/policy-as-code/pull/61).