### PR TITLE
Enhancement of CLI functionality and improvement in database handling in ghastoolkit

### DIFF
--- a/src/ghastoolkit/codeql/cli.py
+++ b/src/ghastoolkit/codeql/cli.py
@@ -235,7 +235,10 @@ class CodeQL:
         return []
 
     def getResults(
-        self, database: CodeQLDatabase, path: Optional[str] = None, save_sarif: bool = False
+        self,
+        database: CodeQLDatabase,
+        path: Optional[str] = None,
+        save_sarif: bool = False,
     ) -> CodeQLResults:
         """Get the interpreted results from CodeQL."""
         sarif = os.path.join(tempfile.gettempdir(), "codeql-result.sarif")
@@ -257,7 +260,9 @@ class CodeQL:
             data = json.load(handle)
 
         if save_sarif:
-            shutil.copyfile(sarif, os.path.join(database.path, f"{database.language}-results.sarif"))
+            shutil.copyfile(
+                sarif, os.path.join(database.path, f"{database.language}-results.sarif")
+            )
         # clean up
         os.remove(sarif)
 

--- a/src/ghastoolkit/codeql/databases.py
+++ b/src/ghastoolkit/codeql/databases.py
@@ -246,16 +246,18 @@ class CodeQLDatabase:
             zf.extractall(output_db)
 
         logger.debug(f" >>> {output_db}")
-        codeql_lang_path = os.path.join(output_db, self.language)
+        # CodeQL DB is in a folder called `codeql_db` or the language name
+        lang_path = os.path.join(output_db, self.language) 
+        codeql_db_path = lang_path if os.path.exists(lang_path) else os.path.join(output_db, "codeql_db")
 
-        if os.path.exists(codeql_lang_path):
+        if os.path.exists(codeql_db_path):
             logger.debug(f"Moving Database...")
 
             if os.path.exists(output):
                 logger.debug(f"Removing old DB :: {output}")
                 shutil.rmtree(output)
 
-            shutil.move(codeql_lang_path, output)
+            shutil.move(codeql_db_path, output)
             self.path = output
             return output
 

--- a/src/ghastoolkit/codeql/databases.py
+++ b/src/ghastoolkit/codeql/databases.py
@@ -247,8 +247,12 @@ class CodeQLDatabase:
 
         logger.debug(f" >>> {output_db}")
         # CodeQL DB is in a folder called `codeql_db` or the language name
-        lang_path = os.path.join(output_db, self.language) 
-        codeql_db_path = lang_path if os.path.exists(lang_path) else os.path.join(output_db, "codeql_db")
+        lang_path = os.path.join(output_db, self.language)
+        codeql_db_path = (
+            lang_path
+            if os.path.exists(lang_path)
+            else os.path.join(output_db, "codeql_db")
+        )
 
         if os.path.exists(codeql_db_path):
             logger.debug(f"Moving Database...")


### PR DESCRIPTION
This pull request to `ghastoolkit` includes modifications to improve the functionality of the `cli.py` and `databases.py` files. The most important changes include adding new parameters to the `runQuery` and `getResults` functions in `cli.py` to affect the saving of SARIF files and the display of progress in the terminal, and modifying the `downloadDatabase` function in `databases.py` to handle databases in different folder names and move them to the output directory.

Main interface changes:

* <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61R152-R153">`src/ghastoolkit/codeql/cli.py`</a>: Modified the `runQuery` and `getResults` functions to include new parameters `save_sarif` and `xterm_progress`. <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61R152-R153">[1]</a> <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61R178">[2]</a> <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61L185-R189">[3]</a> <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61L235-R238">[4]</a> <a href="diffhunk://#diff-7cd8d949688ebb3a344279c1e30646b2d9f563fd307c447ab82a3413f0cb0e61R259-R260">[5]</a>

Database handling improvements:

* <a href="diffhunk://#diff-f6828d5b73e1ade21b81ee24c44140f6d7d31c571cb7f20ebc17a7eaa9151329L249-R260">`src/ghastoolkit/codeql/databases.py`</a>: Modified the `downloadDatabase` function to handle databases in different folder names and move them to the output directory.