### PR TITLE
Fix CWE issues with advisories and Dependabot GraphQL issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghastoolkit"
-version = "0.11.0"
+version = "0.11.1"
 authors = [{ name = "GeekMasher" }]
 description = "GitHub Advanced Security Python Toolkit"
 readme = "README.md"

--- a/src/ghastoolkit/__init__.py
+++ b/src/ghastoolkit/__init__.py
@@ -2,7 +2,7 @@
 __name__ = "ghastoolkit"
 __title__ = "GHAS Toolkit"
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 __description__ = "GitHub Advanced Security Python Toolkit"
 __summary__ = """\

--- a/src/ghastoolkit/octokit/dependabot.py
+++ b/src/ghastoolkit/octokit/dependabot.py
@@ -105,11 +105,14 @@ class Dependabot:
                 "GetDependencyAlerts",
                 options={"owner": self.repository.owner, "repo": self.repository.repo},
             )
-            alerts = (
-                data.get("data", {})
-                .get("repository", {})
-                .get("vulnerabilityAlerts", {})
-            )
+            repo = data.get("data", {}).get("repository", {})
+            if not repo:
+                logger.error(f"Failed to get GraphQL repository")
+                logger.error(
+                    "This could be due to a lack of permissions or access token"
+                )
+                raise Exception(f"Failed to get GraphQL repository alerts")
+            alerts = repo.get("vulnerabilityAlerts", {})
 
             for alert in alerts.get("edges", []):
                 data = alert.get("node", {})

--- a/src/ghastoolkit/octokit/octokit.py
+++ b/src/ghastoolkit/octokit/octokit.py
@@ -175,7 +175,7 @@ class RestRequest:
         self,
         path: str,
         parameters: dict = {},
-        expected: int = 200,
+        expected: Optional[int] = 200,
         authenticated: bool = False,
         display_errors: bool = True,
     ) -> Union[dict, list[dict]]:
@@ -210,7 +210,7 @@ class RestRequest:
             response = self.session.get(url, params=params)
             response_json = response.json()
 
-            if response.status_code != expected:
+            if expected and response.status_code != expected:
                 if display_errors:
                     logger.error(f"Error code from server :: {response.status_code}")
                     logger.error(f"Content :: {response_json}")

--- a/src/ghastoolkit/supplychain/advisories.py
+++ b/src/ghastoolkit/supplychain/advisories.py
@@ -160,6 +160,15 @@ class Advisory(OctoItem):
         self.ghsa_id = self.ghsa_id.lower()
         self.severity = self.severity.lower()
 
+        # cwes checking and processing
+        cwes = []
+        for cwe in self.cwes:
+            if isinstance(cwe, dict):
+                cwes.append(cwe.get("cwe_id"))
+            else:
+                cwes.append(cwe)
+        self.cwes = cwes
+
     @staticmethod
     def load(path: str) -> "Advisory":
         """Load Advisory from path using GitHub Advisory Spec."""

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -33,6 +33,13 @@ class TestAdvisories(unittest.TestCase):
         alert = self.advisories.check(dep)
         self.assertEquals(alert, [ad])
 
+    def test_advisory_cwes(self):
+        ad = Advisory("rand", "high", cwes=["CWE-1234"])
+        self.assertEquals(ad.cwes, ["CWE-1234"])
+
+        ad = Advisory("rand", "high", cwes=[{"cwe_id": "CWE-1234"}])
+        self.assertEquals(ad.cwes, ["CWE-1234"])
+
     def test_affect_check(self):
         dep = Dependency("ghastoolkit", "com.geekmasher", "0.8", "maven")
         affect = AdvisoryAffect(


### PR DESCRIPTION
This pull request includes modifications to the `ghastoolkit` package to improve error handling, enhance type checking, and process CWEs. The most significant changes are in the `getAlertsGraphQL` method in `dependabot.py`, the `get` method in `octokit.py`, and the `__post_init__` method in `advisories.py`.

Error handling and logging:

* <a href="diffhunk://#diff-5c97a427ff057c148668cb63e5aea09904fddb4c6494c8a2a1442d5f550266e7L108-R115">`src/ghastoolkit/octokit/dependabot.py`</a>: The `getAlertsGraphQL` method now checks if the repository data is retrieved successfully from the GraphQL query. If not, it logs an error message and raises an exception.

Type checking and handling:

* <a href="diffhunk://#diff-803e42515af4b209bdcbfa1a8d7b0837225adb8a8e04781c6b6a27872f9ac428L178-R178">`src/ghastoolkit/octokit/octokit.py`</a>: The `get` method now accepts an optional `expected` parameter, and only checks the response status code if `expected` is not `None`. <a href="diffhunk://#diff-803e42515af4b209bdcbfa1a8d7b0837225adb8a8e04781c6b6a27872f9ac428L178-R178">[1]</a> <a href="diffhunk://#diff-803e42515af4b209bdcbfa1a8d7b0837225adb8a8e04781c6b6a27872f9ac428L213-R213">[2]</a>

Processing CWEs:

* <a href="diffhunk://#diff-29013f389767585b3b0adbf156500f8f61fc447306633232b98ba2ca14b53670R163-R171">`src/ghastoolkit/supplychain/advisories.py`</a>: The `__post_init__` method now processes the `cwes` attribute to ensure it only contains CWE IDs, regardless of whether the original CWEs are dictionaries or not.